### PR TITLE
Removing Courses Alimentation as default category.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -51,7 +51,7 @@ func (c *csvParser) parse(reader csvreader) (transactions []budget.Transaction, 
 			if c.isDebitTransaction(each) {
 				debit, err := c.parseAmount(each[2])
 				if err == nil {
-					t := budget.NewTransaction(date, libelle, "", "Courses Alimentation", debit)
+					t := budget.NewTransaction(date, libelle, "", "", debit)
 					transactions = append(transactions, t)
 				} else {
 					zap.S().Error(err)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -16,7 +16,7 @@ func TestParseTransactions(t *testing.T) {
 	assert.Equal(t, debit.Date, "18/12/2019")
 	assert.Equal(t, debit.Description, "Paiement Par Carte Brulerie Des Capuci Brest 15/02 ")
 	assert.Equal(t, debit.Comment, "")
-	assert.Equal(t, debit.Category, "Courses Alimentation")
+	assert.Equal(t, debit.Category, "")
 	assert.Equal(t, debit.Value, 3.18)
 	credit := transactions[1]
 	assert.Equal(t, credit.Date, "18/12/2019")
@@ -28,13 +28,13 @@ func TestParseTransactions(t *testing.T) {
 	assert.Equal(t, cheque1.Date, "28/02/2020")
 	assert.Equal(t, cheque1.Description, "Cheque Emis 8936392")
 	assert.Equal(t, cheque1.Comment, "")
-	assert.Equal(t, cheque1.Category, "Courses Alimentation")
+	assert.Equal(t, cheque1.Category, "")
 	assert.Equal(t, cheque1.Value, 118.8)
 	cheque2 := transactions[3]
 	assert.Equal(t, cheque2.Date, "29/02/2020")
 	assert.Equal(t, cheque2.Description, "Cheque Emis 5423696")
 	assert.Equal(t, cheque2.Comment, "")
-	assert.Equal(t, cheque2.Category, "Courses Alimentation")
+	assert.Equal(t, cheque2.Category, "")
 	assert.Equal(t, cheque2.Value, 39.0)
 	grand := transactions[4]
 	assert.Equal(t, grand.Date, "01/01/2020")


### PR DESCRIPTION
This PR fixes the issue #3 of assign Courses Alimentation as default category for some debit transactions and it consists of:
1. Update parser.go by replacing "Courses Alimentation" by "" when creating a new Transaction.
2. Modify parser_test.go to fit to the new change.