### PR TITLE
fix: 🔊 write logs as json

### DIFF
--- a/categorizer/categorizer.go
+++ b/categorizer/categorizer.go
@@ -26,10 +26,13 @@ func (c *categorizerImpl) Categorize(t budget.Transaction) budget.Transaction {
 	for key, value := range c.libelles {
 		if strings.Contains(t.Description, key) {
 			output.Category = value
-			zap.S().Infof("Assigning category '%s' to transaction with description '%s'", value, t.Description)
+			zap.L().Info("Assigning category to transaction",
+				zap.String("category", value),
+				zap.String("transaction-description", t.Description))
 			return output
 		}
 	}
-	zap.S().Warnf("No matching categories found for transaction with description '%s'", t.Description)
+	zap.L().Warn("No matching categories found for transaction",
+		zap.String("transaction-description", t.Description))
 	return output
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,21 +31,27 @@ func GetConfiguration(downloader s3manageriface.DownloaderAPI) Configuration {
 	if ok {
 		objectKey, ok := os.LookupEnv("CONFIGURATION_FILE_OBJECT_KEY")
 		if ok {
-			zap.S().Infof("Downloading configuration file '%s' from bucket '%s'", objectKey, bucket)
+			zap.L().Info("Downloading configuration file from S3",
+				zap.String("bucket", bucket),
+				zap.String("object-key", objectKey))
 			buff := &aws.WriteAtBuffer{}
 			_, err := downloader.Download(buff, &s3.GetObjectInput{
 				Bucket: aws.String(bucket),
 				Key:    aws.String(objectKey),
 			})
 			if err == nil {
-				zap.S().Infof("Downloaded configuration file '%s' from bucket '%s'", objectKey, bucket)
+				zap.L().Info("Successfully downloaded configuration file from S3",
+					zap.String("bucket", bucket),
+					zap.String("object-key", objectKey))
 				return parseConfiguration([]byte(buff.Bytes()))
 			}
-			zap.S().Warnf("Could not download configuration file '%s' from bucket '%s'", objectKey, bucket)
-			zap.S().Error(err)
+			zap.L().Error("Error while downloading configuration file",
+				zap.String("bucket", bucket),
+				zap.String("object-key", objectKey),
+				zap.Error(err))
 		}
 	}
-	zap.S().Warn("Using default configuration")
+	zap.L().Warn("Using default configuration")
 	return parseConfiguration([]byte(defaultConfiguration))
 }
 

--- a/messaging/message.go
+++ b/messaging/message.go
@@ -57,17 +57,21 @@ func (b *sqsbroker) sendBatch(list []budget.Transaction) error {
 		entries[i] = m
 	}
 	request.SetEntries(entries)
-	zap.S().Infof("Sending a batch of %d messages to SQS", len(list))
+	zap.L().Info("Sending a batch of messages to SQS",
+		zap.Int("batch-size", len(list)))
 	result, err := b.svc.SendMessageBatch(request)
 	if err != nil {
-		zap.S().Errorf("Error while sending message", err)
+		zap.L().Error("Error while sending message", zap.Error(err))
 		return err
 	}
 	for _, s := range result.Successful {
-		zap.S().Infof("Message send successfully with id '%v'", *s.MessageId)
+		zap.L().Info("Message send successfully to SQS",
+			zap.Stringp("message-id", s.MessageId))
 	}
 	for _, f := range result.Failed {
-		zap.S().Infof("Error while sending message with id '%v' %v", *f.Id, *f.Message)
+		zap.L().Warn("Error while sending message to SQS",
+			zap.Stringp("error-message", f.Message),
+			zap.Stringp("message-id", f.Id))
 	}
 	return nil
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -54,7 +54,7 @@ func (c *csvParser) parse(reader csvreader) (transactions []budget.Transaction, 
 					t := budget.NewTransaction(date, libelle, "", "", debit)
 					transactions = append(transactions, t)
 				} else {
-					zap.S().Error(err)
+					zap.L().Error("Error while parsing transaction amount", zap.Error(err))
 				}
 			} else {
 				credit, err := c.parseAmount(each[3])
@@ -62,12 +62,13 @@ func (c *csvParser) parse(reader csvreader) (transactions []budget.Transaction, 
 					t := budget.NewTransaction(date, libelle, "", "", -credit)
 					transactions = append(transactions, t)
 				} else {
-					zap.S().Error(err)
+					zap.L().Error("Error while parsing transaction amount", zap.Error(err))
 				}
 			}
 		}
 	}
-	zap.S().Infof("Found %v transactions", len(transactions))
+	zap.L().Info("Finish parsing the transactions file",
+		zap.Int("number-transactions", len(transactions)))
 	return transactions, nil
 }
 


### PR DESCRIPTION
## What?
Update the logs so that the values are written as json

## Why?
This is more convenient when analysing the logs and faster as well when writing the logs.

## How?
Replaced calls to `zap.S().Infof(...)` by `zap.L().Info()`.

## Useful links?
https://www.jbleduigou.com/22/2/21/aws-lambda-pourquoi-%C3%A9crire-des-logs-au-format-json/