### PR TITLE
chore: ♻️  improve readability by extracting function for default config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ samconfig.toml
 
 # IntelliJ config
 .idea
+*.iml

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,25 @@ func (m *mockReadCloser) Read(p []byte) (n int, err error) {
 	return 0, io.ErrUnexpectedEOF
 }
 
-func TestGetConfigurationShouldUseDefault(t *testing.T) {
+func TestGetConfigurationShouldUseDefaultGivenNoBucket(t *testing.T) {
+	os.Unsetenv("CONFIGURATION_FILE_BUCKET")
+	os.Unsetenv("CONFIGURATION_FILE_OBJECT_KEY")
+
+	m := mock.NewDownloader("")
+	configuration := GetConfiguration(context.Background(), m)
+
+	assert.Equal(t, len(configuration.Categories), 1)
+	assert.Equal(t, configuration.Categories[0], "Courses Alimentation")
+	assert.Equal(t, len(configuration.Keywords), 2)
+	assert.Equal(t, configuration.Keywords["Express Proxi Saint Thonan"], "Courses Alimentation")
+	assert.Equal(t, configuration.Keywords["Courses Alimentation"], "Courses Alimentation")
+	m.AssertExpectations(t)
+}
+
+func TestGetConfigurationShouldUseDefaultGivenNoObjectKey(t *testing.T) {
+	os.Setenv("CONFIGURATION_FILE_BUCKET", "mybucket")
+	os.Unsetenv("CONFIGURATION_FILE_OBJECT_KEY")
+
 	m := mock.NewDownloader("")
 	configuration := GetConfiguration(context.Background(), m)
 


### PR DESCRIPTION
### What?
Refactor the config component to extract the logic for returning default config.

### Why?
Currently there is a lot of code duplication.  
This is error prone.  
Also it is less readable than having a common function for that.

### How?
Extracted the logic to a common function and replaced the existing code to calls to this function.  
After checking code coverage I also realized there was on case that was not covered, so I added a new unit test.